### PR TITLE
Improve coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 build/
 dist/
 dists/
+pip-wheel-metadata
 .eggs
 *.egg-info/
 
@@ -25,3 +26,4 @@ docs/_build/
 .idea
 .cache
 .mypy_cache
+.DS_STORE

--- a/src/grid_strategy/_abc.py
+++ b/src/grid_strategy/_abc.py
@@ -35,7 +35,7 @@ class GridStrategy(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def get_grid_arrangement(cls, n):
+    def get_grid_arrangement(cls, n):  # pragma: nocover
         pass
 
     def get_gridspec(self, grid_arrangement):

--- a/src/grid_strategy/strategies.py
+++ b/src/grid_strategy/strategies.py
@@ -170,7 +170,7 @@ class SquareStrategy(GridStrategy):
         """
         total = n_more + n_less
         if total % 2:
-            msg = ("Expected an even number of values, " + "got {} + {}").format(
+            msg = "Expected an even number of values, got {} + {}".format(
                 n_more, n_less
             )
             raise ValueError(msg)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest import mock
+
+from grid_strategy.strategies import SquareStrategy
+
+
+class SpecValue:
+    def __init__(self, rows, cols, parent=None):
+        self.rows = rows
+        self.cols = cols
+        self.parent = parent
+
+    def __repr__(self):  # pragma: nocover
+        return f"{self.__class__.__name__}({self.rows}, {self.cols})"
+
+    def __eq__(self, other):
+        return self.rows == other.rows and self.cols == other.cols
+
+
+class GridSpecMock:
+    def __init__(self, nrows, ncols, *args, **kwargs):
+        self._nrows_ = nrows
+        self._ncols_ = ncols
+
+        self._args_ = args
+        self._kwargs_ = kwargs
+
+    def __getitem__(self, key_tup):
+        return SpecValue(*key_tup, self)
+
+
+@pytest.fixture
+def gridspec_mock():
+    class Figure:
+        pass
+
+    def figure(*args, **kwargs):
+        return Figure()
+
+    with mock.patch(f"grid_strategy._abc.gridspec.GridSpec", new=GridSpecMock) as g:
+        with mock.patch(f"grid_strategy._abc.plt.figure", new=figure):
+            yield g
+
+
+@pytest.mark.parametrize(
+    "align, n, exp_specs",
+    [
+        ("center", 1, [(0, slice(0, 1))]),
+        ("center", 2, [(0, slice(0, 1)), (0, slice(1, 2))]),
+        ("center", 3, [(0, slice(0, 2)), (0, slice(2, 4)), (1, slice(1, 3))]),
+        ("left", 3, [(0, slice(0, 2)), (0, slice(2, 4)), (1, slice(0, 2))]),
+        ("right", 3, [(0, slice(0, 2)), (0, slice(2, 4)), (1, slice(2, 4))]),
+        ("justified", 3, [(0, slice(0, 1)), (0, slice(1, 2)), (1, slice(0, 2))]),
+        (
+            "center",
+            8,
+            [
+                (0, slice(0, 2)),
+                (0, slice(2, 4)),
+                (0, slice(4, 6)),
+                (1, slice(1, 3)),
+                (1, slice(3, 5)),
+                (2, slice(0, 2)),
+                (2, slice(2, 4)),
+                (2, slice(4, 6)),
+            ],
+        ),
+        ("left", 2, [(0, slice(0, 1)), (0, slice(1, 2))]),
+    ],
+)
+def test_square_spec(gridspec_mock, align, n, exp_specs):
+    ss = SquareStrategy(align)
+
+    act = ss.get_grid(n)
+    exp = [SpecValue(*spec) for spec in exp_specs]
+
+    assert act == exp

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -46,7 +46,13 @@ def test_rectangular_strategy(rectangular_strategy, num_plots, grid_arrangement)
         (9, (3, 3, 3)),
         (10, (3, 4, 3)),
         (12, (4, 4, 4)),
+        (14, (3, 4, 4, 3)),
+        (17, (3, 4, 3, 4, 3)),
         (20, (5, 5, 5, 5)),
+        (31, (6, 6, 7, 6, 6)),
+        (34, (6, 5, 6, 6, 5, 6)),
+        (58, (7, 8, 7, 7, 7, 7, 8, 7)),
+        (94, (9, 10, 9, 10, 9, 9, 10, 9, 10, 9)),
     ],
 )
 def test_square_strategy(square_strategy, num_plots, grid_arrangement):

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -60,10 +60,13 @@ def test_square_strategy(square_strategy, num_plots, grid_arrangement):
 
 
 # Test for bad input
-def test_strategy_with_bad_input(rectangular_strategy, square_strategy):
+@pytest.mark.parametrize("n", [-1, -1000])
+def test_rectangular_strategy_with_bad_input(rectangular_strategy, n):
     with pytest.raises(ValueError):
-        rectangular_strategy.get_grid(-1)
-        rectangular_strategy.get_grid(-1000)
+        rectangular_strategy.get_grid(n)
 
-        square_strategy.get_grid(-1)
-        square_strategy.get_grid(-110)
+
+@pytest.mark.parametrize("n", [-1, -1000])
+def test_square_strategy_with_bad_input(square_strategy, n):
+    with pytest.raises(ValueError):
+        square_strategy.get_grid(n)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     coverage
 commands = pytest --cov-config="{toxinidir}/tox.ini" \
                   --cov="{envsitepackagesdir}/grid_strategy" \
+                  --cov="{toxinidir}/tests" \
                   {posargs}
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ deps =
     pytest-cov >= 2.0.0
     coverage
 commands = pytest --cov-config="{toxinidir}/tox.ini" \
-                  --cov="{envsitepackagesdir}/grid_strategy"
+                  --cov="{envsitepackagesdir}/grid_strategy" \
+                  {posargs}
 
 [testenv:coverage]
 description = combine coverage data and create reports


### PR DESCRIPTION
The biggest problem with the coverage was that we could not test `GridSpec` objects, so I have created a small mock that allows us to ensure the right grid specs are created.

This brings the code coverage up to 98%. The only remaining untested lines are never hit by the "main" functions, and I am somewhat reluctant to directly test `stripe_even` and `stripe_odd`, because I'm not entirely sure why I made them public.