### PR TITLE
Add tests for stripe_even

### DIFF
--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -70,3 +70,21 @@ def test_rectangular_strategy_with_bad_input(rectangular_strategy, n):
 def test_square_strategy_with_bad_input(square_strategy, n):
     with pytest.raises(ValueError):
         square_strategy.get_grid(n)
+
+
+# Test for the `stripe_even` functions - it is not entirely clear that these
+# will remain public, so do not take the fact that it is tested as an
+# indication that this is a critical part of the public interface
+@pytest.mark.parametrize(
+    "args, exp", [((4, 3, 2, 4), (3, 4, 3, 3, 4, 3)), ((3, 2, 1, 1), (2, 2, 1, 2))]
+)
+def test_stripe_even(args, exp):
+    act = strategies.SquareStrategy.stripe_even(*args)
+
+    assert act == exp
+
+
+def test_stripe_even_value_error():
+    # This fails when the total number (n_more + n_less) is not even
+    with pytest.raises(ValueError):
+        strategies.SquareStrategy.stripe_even(3, 1, 4, 1)


### PR DESCRIPTION
The existing strategies can't ever use stripe_even in these cases, but stripe_even is public, so I am adding tests for it directly, even though I am not terribly comfortable guaranteeing this behavior.

I am mainly doing this because the lure of 100% test coverage is too strong to resist.